### PR TITLE
feat: add TypeScript support and update `pnpm` environment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,7 @@ updates:
     schedule:
       interval: weekly
       day: tuesday
+    commit-message:
+      include: scope
+      prefix: "fix"
+      prefix-development: "chore"

--- a/README.md
+++ b/README.md
@@ -210,6 +210,20 @@ Return: `this`
 
 Save data to `package.json` synchronously.
 
+## TypeScript Support
+
+This project features comprehensive [TypeScript](https://www.typescriptlang.org/) support with full type definitions.
+
+### Type Definitions
+
+The library exports the following main types:
+
+- `IPkg` - Interface for the main Pkg class
+- `IVersion` - Interface for the Version class  
+- `PkgOptions` - Options for creating a Pkg instance
+- `PackageData` - Type definition for package.json structure
+- `VersionSegment` - Type for version segments (`'major' | 'minor' | 'patch' | 'prerelease'`)
+
 ## Credits
 
 - Original codebase credits goes to [EGOIST](https://github.com/egoist)'s [update-pkg](https://github.com/egoist/update-pkg)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,241 @@
+/**
+ * TypeScript declarations for update-pkg-extended
+ */
+
+/**
+ * Options for creating a new Pkg instance
+ */
+export interface PkgOptions {
+  /** Whether to create a new package.json if it doesn't exist */
+  create?: boolean;
+}
+
+/**
+ * Represents a version segment that can be retrieved
+ */
+export type VersionSegment = 'major' | 'minor' | 'patch' | 'prerelease';
+
+/**
+ * Package.json data structure
+ */
+export interface PackageData {
+  name?: string;
+  version?: string;
+  description?: string;
+  main?: string;
+  type?: 'module' | 'commonjs';
+  exports?: string | Record<string, unknown>;
+  scripts?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  keywords?: string[];
+  author?: string | {
+    name?: string;
+    email?: string;
+    url?: string;
+  };
+  license?: string;
+  repository?: string | {
+    type?: string;
+    url?: string;
+  };
+  bugs?: string | {
+    url?: string;
+    email?: string;
+  };
+  homepage?: string;
+  files?: string[];
+  engines?: Record<string, string>;
+  packageManager?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Version class interface
+ */
+export interface IVersion {
+  /** The underlying package data */
+  data: PackageData;
+
+  /**
+   * Get version or version segment
+   * @param segment - The version segment to get (optional)
+   * @returns The version string or segment value
+   */
+  get(segment?: VersionSegment): string | null;
+
+  /**
+   * Increment major version and reset minor/patch to 0
+   * @returns The Version instance for chaining
+   */
+  newMajor(): IVersion;
+
+  /**
+   * Increment minor version and reset patch to 0
+   * @returns The Version instance for chaining
+   */
+  newMinor(): IVersion;
+
+  /**
+   * Increment patch version
+   * @returns The Version instance for chaining
+   */
+  newPatch(): IVersion;
+
+  /**
+   * Set or increment major version
+   * @param major - The major version number (optional)
+   * @returns The Version instance for chaining
+   */
+  major(major?: number): IVersion;
+
+  /**
+   * Set or increment minor version
+   * @param minor - The minor version number (optional)
+   * @returns The Version instance for chaining
+   */
+  minor(minor?: number): IVersion;
+
+  /**
+   * Set or increment patch version
+   * @param patch - The patch version number (optional)
+   * @returns The Version instance for chaining
+   */
+  patch(patch?: number): IVersion;
+
+  /**
+   * Set prerelease version
+   * @param preleaseIdentifier - The prerelease identifier (e.g., 'alpha', 'beta', 'rc')
+   * @param preleaseVersion - The prerelease version number (optional)
+   * @returns The Version instance for chaining
+   */
+  prerelease(preleaseIdentifier: string, preleaseVersion?: number): IVersion;
+}
+
+/**
+ * Package class interface
+ */
+export interface IPkg {
+  /** The package.json file path */
+  path: string;
+  
+  /** The version instance for version manipulation */
+  version: IVersion;
+
+  /** Configuration options */
+  options: PkgOptions;
+
+  /**
+   * Set a property in package.json
+   * @param prop - The property path (supports dot notation)
+   * @param value - The value to set
+   * @returns The Pkg instance for chaining
+   */
+  set(prop: string, value: unknown): IPkg;
+
+  /**
+   * Get a property from package.json
+   * @param prop - The property path (supports dot notation)
+   * @param defaultValue - Default value if property doesn't exist
+   * @returns The property value
+   */
+  get(prop: string, defaultValue?: unknown): unknown;
+
+  /**
+   * Update a property using a function
+   * @param prop - The property path (supports dot notation)
+   * @param fn - Function that receives current value and returns new value
+   * @returns The Pkg instance for chaining
+   */
+  update(prop: string, fn: (currentValue: unknown) => unknown): IPkg;
+
+  /**
+   * Append value to an array property
+   * @param prop - The property path (supports dot notation)
+   * @param value - The value to append
+   * @returns The Pkg instance for chaining
+   */
+  append(prop: string, value: unknown): IPkg;
+
+  /**
+   * Prepend value to an array property
+   * @param prop - The property path (supports dot notation)
+   * @param value - The value to prepend
+   * @returns The Pkg instance for chaining
+   */
+  prepend(prop: string, value: unknown): IPkg;
+
+  /**
+   * Delete a property from package.json
+   * @param prop - The property path (supports dot notation)
+   * @returns The Pkg instance for chaining
+   */
+  del(prop: string): IPkg;
+
+  /**
+   * Check if a property exists in package.json
+   * @param prop - The property path (supports dot notation)
+   * @returns True if property exists
+   */
+  has(prop: string): boolean;
+
+  /**
+   * Save changes to package.json asynchronously
+   * @returns Promise that resolves when save is complete
+   */
+  save(): Promise<void>;
+
+  /**
+   * Save changes to package.json synchronously
+   * @returns The Pkg instance for chaining
+   */
+  saveSync(): IPkg;
+}
+
+/**
+ * Version manipulation class
+ */
+declare class Version implements IVersion {
+  data: PackageData;
+
+  constructor(sourceData?: PackageData);
+
+  get(segment?: VersionSegment): string | null;
+  newMajor(): Version;
+  newMinor(): Version;
+  newPatch(): Version;
+  major(major?: number): Version;
+  minor(minor?: number): Version;
+  patch(patch?: number): Version;
+  prerelease(preleaseIdentifier: string, preleaseVersion?: number): Version;
+}
+
+/**
+ * Package manipulation class
+ */
+declare class Pkg implements IPkg {
+  path: string;
+  version: Version;
+  options: PkgOptions;
+
+  constructor(cwd?: string, options?: PkgOptions);
+
+  set(prop: string, value: unknown): Pkg;
+  get(prop: string, defaultValue?: unknown): unknown;
+  update(prop: string, fn: (currentValue: unknown) => unknown): Pkg;
+  append(prop: string, value: unknown): Pkg;
+  prepend(prop: string, value: unknown): Pkg;
+  del(prop: string): Pkg;
+  has(prop: string): boolean;
+  save(): Promise<void>;
+  saveSync(): Pkg;
+}
+
+// Default export
+declare const _default: typeof Pkg;
+export default _default;
+
+// Export Version class as named export
+export { Version };

--- a/package.json
+++ b/package.json
@@ -34,8 +34,10 @@
   },
   "type": "module",
   "exports": "./src/index.js",
+  "types": "./index.d.ts",
   "files": [
-    "/src/*.js"
+    "/src/*.js",
+    "/index.d.ts"
   ],
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "coverage": "c8 --check-coverage --lines 100 npm run test",
     "coverage:lcov": "c8 --check-coverage --lines 100 --reporter lcov npm run test"
   },
-  "packageManager": "pnpm@10.6.5+sha512.cdf928fca20832cd59ec53826492b7dc25dc524d4370b6b4adbf65803d32efaa6c1c88147c0ae4e8d579a6c9eec715757b50d4fa35eea179d868eada4ed043af",
+  "packageManager": "pnpm@10.17.0+sha512.fce8a3dd29a4ed2ec566fb53efbb04d8c44a0f05bc6f24a73046910fb9c3ce7afa35a0980500668fa3573345bd644644fa98338fa168235c80f4aa17aa17fbef",
   "devDependencies": {
     "ava": "^6.2.0",
     "c8": "^10.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -826,10 +826,6 @@ packages:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
 
-  type-fest@4.37.0:
-    resolution: {integrity: sha512-S/5/0kFftkq27FPNye0XM1e2NsnoD/3FS+pBmbjmmtLT6I+i344KoOf7pvXreaFsDamWeaJX55nczA1m5PsBDg==}
-    engines: {node: '>=16'}
-
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
@@ -1476,7 +1472,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.26.2
       index-to-position: 1.0.0
-      type-fest: 4.37.0
+      type-fest: 4.41.0
 
   parse-ms@4.0.0: {}
 
@@ -1517,7 +1513,7 @@ snapshots:
       '@types/normalize-package-data': 2.4.4
       normalize-package-data: 6.0.2
       parse-json: 8.2.0
-      type-fest: 4.37.0
+      type-fest: 4.41.0
       unicorn-magic: 0.1.0
 
   require-directory@2.1.1: {}
@@ -1651,8 +1647,6 @@ snapshots:
   tr46@0.0.3: {}
 
   type-fest@0.13.1: {}
-
-  type-fest@4.37.0: {}
 
   type-fest@4.41.0: {}
 


### PR DESCRIPTION
This PR focuses on adding TypeScript support, updating dependencies, and making minor configuration enhancements.

The most important changes are outlined below:

**TypeScript Support Enhancements:**

* Added a `types` entry (`index.d.ts`) to `package.json` and included it in the published files, ensuring consumers get type definitions.
* Updated the `README.md` with a new section describing TypeScript support and the main exported types.

**Dependency Updates:**

* Updated the `packageManager` field in `package.json` to use a newer version of `pnpm`.

**Configuration Improvements:**

* Enhanced the Dependabot configuration to customize commit message prefixes and include scope information for better clarity in automated dependency updates.