### PR TITLE
fix: update Version feature to fix typo in `prerelease` support

### DIFF
--- a/src/version.js
+++ b/src/version.js
@@ -18,7 +18,8 @@ class Version {
       case 'patch':
         return this._v.patch.toString()
 
-      case 'prelease':
+      case 'prerelease':
+      case 'prelease':  // Backward compatibility for typo
         return this._v.prerelease && this._v.prerelease.length > 0 ? this._v.prerelease.join('.') : null
 
       default:
@@ -61,15 +62,15 @@ class Version {
     return this._set()
   }
 
-  prerelease (preleaseIdentifier, preleaseVersion) {
-    if (!preleaseIdentifier) {
-      throw new Error('Missing required argument preleaseIdentifier')
+  prerelease (prereleaseIdentifier, prereleaseVersion) {
+    if (!prereleaseIdentifier) {
+      throw new Error('Missing required argument prereleaseIdentifier')
     }
 
-    if (preleaseVersion !== undefined && preleaseVersion !== null) {
-      this._v.prerelease = [preleaseIdentifier, preleaseVersion]
+    if (prereleaseVersion !== undefined && prereleaseVersion !== null) {
+      this._v.prerelease = [prereleaseIdentifier, prereleaseVersion]
     } else {
-      this._v.inc('prerelease', preleaseIdentifier)
+      this._v.inc('prerelease', prereleaseIdentifier)
     }
 
     return this._set()

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -93,3 +93,83 @@ test('semver inc patch without prerelease', t => {
   version.inc('patch')
   t.is(version.format(), '1.0.1')
 })
+
+test('semver constructor with null version', t => {
+  const version = parse(null)
+  t.is(version.format(), '0.0.0')
+})
+
+test('semver constructor with undefined version', t => {
+  const version = parse(undefined)
+  t.is(version.format(), '0.0.0')
+})
+
+test('semver parse version with v prefix', t => {
+  const version = parse('v1.2.3')
+  t.is(version.format(), '1.2.3')
+})
+
+test('semver parse version with missing minor and patch', t => {
+  const version = parse('1')
+  t.is(version.format(), '1.0.0')
+})
+
+test('semver parse version with missing patch', t => {
+  const version = parse('1.2')
+  t.is(version.format(), '1.2.0')
+})
+
+test('semver inc prerelease with non-numeric last item', t => {
+  const version = parse('1.0.0-alpha.beta')
+  version.inc('prerelease')
+  t.is(version.format(), '1.0.0-alpha.beta.0')
+})
+
+test('setProperty creates intermediate object when current property is null', t => {
+  const obj = { test: null }
+  setProperty(obj, 'test.nested', 'value')
+  t.deepEqual(obj, { test: { nested: 'value' } })
+})
+
+test('setProperty creates intermediate object when current property is not an object', t => {
+  const obj = { test: 'string' }
+  setProperty(obj, 'test.nested', 'value')
+  t.deepEqual(obj, { test: { nested: 'value' } })
+})
+
+test('semver parse version with empty segments', t => {
+  const version = parse('1..3')
+  t.is(version.format(), '1.0.3')
+})
+
+test('semver parse version with empty trailing segments', t => {
+  const version = parse('1.2.')
+  t.is(version.format(), '1.2.0')
+})
+
+test('semver parse version with empty major segment', t => {
+  const version = parse('.1.2')
+  t.is(version.format(), '0.1.2')
+})
+
+test('semver inc prerelease with complex non-numeric last item', t => {
+  const version = parse('1.0.0-alpha.beta-gamma')
+  version.inc('prerelease')
+  t.is(version.format(), '1.0.0-alpha.beta.0')
+})
+
+test('semver inc prerelease with string numeric last item', t => {
+  // Test case where last prerelease item is a string that looks like a number
+  const version = parse('1.0.0-alpha.5')
+  version.inc('prerelease')
+  t.is(version.format(), '1.0.0-alpha.6')
+})
+
+test('semver inc prerelease with actual numeric last item', t => {
+  // Test case where we explicitly have a numeric last item
+  const version = parse('1.0.0-beta.3')
+  // Manually modify prerelease to have a number instead of string
+  version.prerelease = ['beta', 3]
+  version.inc('prerelease')
+  t.is(version.format(), '1.0.0-beta.4')
+})

--- a/test/version.test.js
+++ b/test/version.test.js
@@ -228,7 +228,7 @@ test('preRelease (get)', t => {
   const version = new Version(Object.assign({}, preReleaseSampleDataAlphaNumeric))
 
   // Expectations
-  t.is(version.get('prelease'), 'alpha.1')
+  t.is(version.get('prerelease'), 'alpha.1')
 })
 
 test('preRelease (get null)', t => {
@@ -236,6 +236,22 @@ test('preRelease (get null)', t => {
   const version = new Version(Object.assign({}, sampleData))
 
   // Expectations
+  t.is(version.get('prerelease'), null)
+})
+
+test('preRelease (get - backward compatibility with typo)', t => {
+  // Setup
+  const version = new Version(Object.assign({}, preReleaseSampleDataAlphaNumeric))
+
+  // Expectations - should still work with the old typo for backward compatibility
+  t.is(version.get('prelease'), 'alpha.1')
+})
+
+test('preRelease (get null - backward compatibility with typo)', t => {
+  // Setup
+  const version = new Version(Object.assign({}, sampleData))
+
+  // Expectations - should still work with the old typo for backward compatibility
   t.is(version.get('prelease'), null)
 })
 


### PR DESCRIPTION
This PR improves the handling of prerelease versions in the `Version` class, fixes a longstanding typo for backward compatibility, and significantly expands test coverage for edge cases in semantic version parsing and manipulation.

**Bug fixes and backward compatibility:**

* Fixed a typo in the `Version` class by correcting `'prelease'` to `'prerelease'` in all relevant methods, while retaining support for the misspelled `'prelease'` key for backward compatibility. (`src/version.js` [[1]](diffhunk://#diff-c1a80fbb2e96a42cd35c5a1e7c3d22df4a225970075327f9a65ddab9510f06a8L21-R22) [[2]](diffhunk://#diff-c1a80fbb2e96a42cd35c5a1e7c3d22df4a225970075327f9a65ddab9510f06a8L64-R73)
* Updated tests to check both the correct `'prerelease'` and the legacy `'prelease'` key to ensure backward compatibility. (`test/version.test.js` [test/version.test.jsL231-R254](diffhunk://#diff-46878634b2a894cbf39870bc9dcc0c2ea551fd212377318984c3bd031cfb1096L231-R254))

**Test coverage improvements:**

* Added comprehensive tests for parsing and formatting semantic versions, including cases with missing or malformed segments, null/undefined input, and versions with a `v` prefix. (`test/utils.test.js` [test/utils.test.jsR96-R175](diffhunk://#diff-3a11a46e9fc8a91f5f4a1148024406fe96fd29d0aa8573e864966b8f088c46faR96-R175))
* Added tests for incrementing prerelease versions, including complex prerelease identifiers and numeric/string edge cases. (`test/utils.test.js` [test/utils.test.jsR96-R175](diffhunk://#diff-3a11a46e9fc8a91f5f4a1148024406fe96fd29d0aa8573e864966b8f088c46faR96-R175))
* Added tests for the `setProperty` utility to ensure it correctly creates intermediate objects when necessary. (`test/utils.test.js` [test/utils.test.jsR96-R175](diffhunk://#diff-3a11a46e9fc8a91f5f4a1148024406fe96fd29d0aa8573e864966b8f088c46faR96-R175))