### PR TITLE
chore(deps-dev): bump @isaacs/brace-expansion from 5.0.0 to 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "coverage": "c8 --check-coverage --lines 100 pnpm run test",
     "coverage:lcov": "c8 --check-coverage --lines 100 --reporter lcov pnpm run test"
   },
-  "packageManager": "pnpm@10.22.0+sha512.bf049efe995b28f527fd2b41ae0474ce29186f7edcb3bf545087bd61fbbebb2bf75362d1307fda09c2d288e1e499787ac12d4fcb617a974718a6051f2eee741c",
+  "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264",
   "devDependencies": {
     "@types/node": "^25.0.1",
     "c8": "^10.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ packages:
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
     engines: {node: 20 || >=22}
 
-  '@isaacs/brace-expansion@5.0.0':
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+  '@isaacs/brace-expansion@5.0.1':
+    resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
     engines: {node: 20 || >=22}
 
   '@isaacs/cliui@8.0.2':
@@ -333,7 +333,7 @@ snapshots:
 
   '@isaacs/balanced-match@4.0.1': {}
 
-  '@isaacs/brace-expansion@5.0.0':
+  '@isaacs/brace-expansion@5.0.1':
     dependencies:
       '@isaacs/balanced-match': 4.0.1
 
@@ -492,7 +492,7 @@ snapshots:
 
   minimatch@10.1.1:
     dependencies:
-      '@isaacs/brace-expansion': 5.0.0
+      '@isaacs/brace-expansion': 5.0.1
 
   minimatch@9.0.5:
     dependencies:


### PR DESCRIPTION
This pull request updates the package manager and a dependency in the project to address minor version bumps and ensure compatibility. The most important changes are:

Dependency and package manager updates:

* Updated the `pnpm` package manager version in `package.json` from `10.22.0` to `10.28.2` to use the latest features and fixes.
* Upgraded the `@isaacs/brace-expansion` dependency from version `5.0.0` to `5.0.1` in `pnpm-lock.yaml` to incorporate upstream improvements and ensure consistency across packages.